### PR TITLE
fixed swarm url

### DIFF
--- a/openhivenpy/gateway/ws.py
+++ b/openhivenpy/gateway/ws.py
@@ -67,7 +67,7 @@ class Websocket(types.Client):
         self._host = host
         self._api_version = api_version
 
-        self._WEBSOCKET_URL = "wss://swarm-dev.hiven.io/socket?encoding=json&compression=text_json"
+        self._WEBSOCKET_URL = "wss://swarm.hiven.io/socket?encoding=json&compression=text_json"
         self._ENCODING = "json"
 
         # In milliseconds


### PR DESCRIPTION
swarm-dev.hiven.io is now swarm.hiven.io for socket

# Summary
basically, devs changed swarm-dev to swarm meaning bot cannot connect to userclient

## Changes
<!-- Mark as ticked by putting an x in the square brackets (i.e [x]) -->
- [x] This is a **MAJOR** change (e.g new class, rewrite)
- [ ] This is a minor change (e.g typo fixed, optimization, bugfix)
- [ ] This does not effect any code (i.e README/documentation change)
  - [ ] If needed, the documentation has been updated..

