### PR TITLE
Merging changes from main into v0.2.dev, where it belongs

### DIFF
--- a/.github/workflows/pytest-macos.yml
+++ b/.github/workflows/pytest-macos.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install pytest
           pip install -r requirements.txt
       - name: pytest
         run: |

--- a/.github/workflows/pytest-win.yml
+++ b/.github/workflows/pytest-win.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install pytest
           pip install -r requirements.txt
       - name: pytest
         run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -34,14 +34,14 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install flake8 pytest
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test with pytest
-      run: |
-        python3 -m pip install -e .
-        cd pytest
-        pytest -q --token=${{ secrets.HIVEN_TOKEN }}
+      - name: Lint with flake8
+        run: |
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      - name: Test with pytest
+        run: |
+          python3 -m pip install -e .
+          cd pytest
+          pytest -q --token=${{ secrets.HIVEN_TOKEN }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -28,9 +28,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install setuptools wheel twine
       - name: Build and publish
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        python setup.py sdist bdist_wheel
-        twine upload dist/*
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          python setup.py sdist bdist_wheel
+          twine upload dist/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,6 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   ones!
 
 ### Added
-
 - Message-Broker for handling incoming events and distribute them to the
   listeners.
 - Event-Buffers, which store the events and will one by one execute the events/
@@ -62,6 +61,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Cache implementation using cache.py, which will hold and store values and
   provide functions for generating data and update the cache correctly. This
   will remove implementations in the data classes itself.
+- Dot-Env Handling, which will now load the openhivenpy.env file on default and
+  update all variables based on the given input. This will avoid None values
+  when an .env file only updates a few values
 
 ### Removed
 - Old structure (everything not mentioned in changed or added is likely gone)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `call_listeners` to call all listeners for an event based on the passed args
   and kwargs. This will call them directly and not utilise the message-broker
   unlike `dispatch_event`
+- Added `HTTPRateLimitError` for receiving http rate-limits (429) and parameter
+  retry_on_rate_limit to raw_request()
 
 ### Changed
 - Rewrite of the base structure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,8 +51,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `call_listeners` to call all listeners for an event based on the passed args
   and kwargs. This will call them directly and not utilise the message-broker
   unlike `dispatch_event`
-- Added `HTTPRateLimitError` for receiving http rate-limits (429) and parameter
+- `HTTPRateLimitError` for receiving http rate-limits (429) and parameter
   retry_on_rate_limit to raw_request()
+- Parameter `remove_listeners` to `HivenClient.close()`, which will, if set to
+  True, remove all listeners created using @client.event(),
+  add_multi_listener() and add_single_listener()
 
 ### Changed
 - Rewrite of the base structure

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 <p align="center">
 
-[![Package Version](https://img.shields.io/badge/package%20version-v0.1.3.2-purple?logo=python)](https://github.com/Luna-Klatzer/openhiven.py)
+[![PyPI version](https://badge.fury.io/py/openhivenpy.svg)](https://badge.fury.io/py/openhivenpy)
 [![Python Version](https://img.shields.io/badge/python->=3.7-blue?logo=python)](https://python.org)
 ![Build](https://img.shields.io/github/workflow/status/Luna-Klatzer/openhiven.py/CodeQL?logo=github)
 ![Lines of Code](https://img.shields.io/tokei/lines/github/Luna-Klatzer/openhiven.py)

--- a/openhivenpy/__init__.py
+++ b/openhivenpy/__init__.py
@@ -31,7 +31,7 @@ SOFTWARE.
 __title__ = "openhiven.py"
 __author__ = "Luna Klatzer"
 __license__ = "MIT"
-__version__ = "0.2.alpha1"
+__version__ = "0.1.4"
 __copyright__ = "Luna Klatzer"
 
 

--- a/openhivenpy/__init__.py
+++ b/openhivenpy/__init__.py
@@ -31,7 +31,7 @@ SOFTWARE.
 __title__ = "openhiven.py"
 __author__ = "Luna Klatzer"
 __license__ = "MIT"
-__version__ = "0.1.4"
+__version__ = "0.2.dev1"
 __copyright__ = "Luna Klatzer"
 
 

--- a/openhivenpy/client/cache.py
+++ b/openhivenpy/client/cache.py
@@ -51,15 +51,17 @@ def _create_default_dict(log_websocket: bool) -> dict:
 
 class ClientCache(dict, HivenObject):
     """
-    Client Cache Class used for storing all data of the Client. Emulates a dictionary and contains additional
-    functions to interact with the Client cache more easily and use functions for better readability.
+    Client Cache Class used for storing all data of the Client. Emulates a
+    dictionary and contains additional functions to interact with the Client
+    cache more easily and use functions for better readability.
     """
 
     def __init__(self, client: HivenClient, log_websocket: bool, **kwargs):
         super(ClientCache, self).__init__(**kwargs)
         self.client = client
         self.update(
-            # Updating the passed dict as well to avoid data being overwritten that were passed with args or kwargs
+            # Updating the passed dict as well to avoid data being overwritten
+            # that were passed with args or kwargs
             utils.update_and_return(
                 _create_default_dict(log_websocket), **kwargs
             )
@@ -69,7 +71,8 @@ class ClientCache(dict, HivenObject):
         """
         Cleans all remaining data after the client exited.
 
-        Not supposed to be called outside of the intended HivenClient.close() method!
+        Not supposed to be called outside of the intended HivenClient.close()
+        method!
         """
         self.update(_create_default_dict(self['log_websocket']))
         self['client_user'] = {}

--- a/openhivenpy/client/hivenclient.py
+++ b/openhivenpy/client/hivenclient.py
@@ -242,7 +242,9 @@ class HivenClient(HivenEventHandler, HivenObject):
                 f"Failed to keep alive connection to Hiven"
             ) from e
 
-    async def close(self, force: bool = False) -> None:
+    async def close(
+            self, force: bool = False, remove_listeners: bool = True
+    ) -> None:
         """
         Closes the Connection to Hiven and stops the running WebSocket and
         the Event Processing Loop
@@ -251,8 +253,11 @@ class HivenClient(HivenEventHandler, HivenObject):
          forced closed, which may lead to running code of event-listeners being
          stopped while performing actions. If False the stopping will wait
          for all running event_listeners to finish
+        :param remove_listeners: If sett to True, it will remove all listeners
+         including the ones created using @client.event(), add_multi_listener()
+         and add_single_listener()
         """
-        await self.connection.close(force)
+        await self.connection.close(force, remove_listeners)
         self.storage.closing_cleanup()
         logger.debug(f"[HIVENCLIENT] Client {repr(self)} was closed")
 

--- a/openhivenpy/events/__init__.py
+++ b/openhivenpy/events/__init__.py
@@ -280,6 +280,10 @@ class HivenEventHandler(HivenObject):
                 "The passed event type is invalid/does not exist"
             )
 
+    def cleanup_listeners(self) -> None:
+        """ Cleanups the listeners and empties all active listeners """
+        self._active_listeners = {}
+
     def dispatch_event(
             self, event_name: str, args: tuple, kwargs: dict
     ) -> None:

--- a/openhivenpy/exceptions.py
+++ b/openhivenpy/exceptions.py
@@ -34,12 +34,13 @@ __all__ = [
 
     'MessageBrokerError', 'EventConsumerLoopError', 'WorkerTaskError',
 
-    'HivenGatewayError', 'KeepAliveError', 'WebSocketMessageError', 'WebSocketFailedError',
-    'WebSocketClosedError', 'RestartSessionError',
+    'HivenGatewayError', 'KeepAliveError', 'WebSocketMessageError',
+    'WebSocketFailedError', 'WebSocketClosedError', 'RestartSessionError',
 
-    'HTTPError', 'HTTPSessionNotReadyError', 'HTTPRequestTimeoutError', 'HTTPFailedRequestError',
-    'HTTPForbiddenError', 'HTTPResponseError', 'HTTPReceivedNoDataError', 'HTTPNotFoundError',
-    'HTTPInternalServerError',
+    'HTTPError', 'HTTPSessionNotReadyError', 'HTTPRequestTimeoutError',
+    'HTTPFailedRequestError', 'HTTPForbiddenError', 'HTTPResponseError',
+    'HTTPReceivedNoDataError', 'HTTPNotFoundError', 'HTTPInternalServerError',
+    'HTTPRateLimitError',
 
     'APIError',
 
@@ -206,9 +207,16 @@ class HTTPNotFoundError(HTTPError):
     error_msg = "Failed to reach the specified endpoint [Code: 404]"
 
 
+class HTTPRateLimitError(HTTPError):
+    """ Received a RateLimit which blocks the request from performing """
+    error_msg = "Failed to reach the specified endpoint due to rate-limit " \
+                "[Code: 429]"
+
+
 class HTTPInternalServerError(HTTPError):
     """ Failed to reach the specified endpoint """
-    error_msg = "Failed to perform request due to Hiven internal server error"
+    error_msg = "Failed to perform request due to Hiven internal server " \
+                "error [Code: 5**]"
 
 
 class HTTPSessionNotReadyError(HTTPError):
@@ -218,12 +226,14 @@ class HTTPSessionNotReadyError(HTTPError):
 
 class HTTPForbiddenError(HTTPFailedRequestError):
     """ The client was forbidden to perform a Request """
-    error_msg = "The client was forbidden to execute a certain task or function!"
+    error_msg = "The client was forbidden to execute a certain task or " \
+                "function!"
 
 
 class HTTPResponseError(HTTPError):
     """ Response was in wrong format or expected data was not received """
-    error_msg = "Failed to handle Response and utilise data! Code: {}! See HTTP logs!"
+    error_msg = "Failed to handle Response and utilise data! Code: {}! " \
+                "See HTTP logs!"
 
 
 class HTTPReceivedNoDataError(HTTPError):
@@ -231,19 +241,26 @@ class HTTPReceivedNoDataError(HTTPError):
     Received a response without the required data field or
     received a 204(No Content) in a request that expected data.
     """
-    error_msg = "Response does not contain the expected Data! Code: {}! See HTTP logs!"
+    error_msg = "Response does not contain the expected Data! Code: {}! " \
+                "See HTTP logs!"
 
 
 # -------- API --------
 
 
 class APIError(HTTPError):
-    """ An exception in an API-related function that was unable to properly interact with the Hiven servers """
+    """
+    An exception in an API-related function that was unable to properly
+    interact with the Hiven servers
+    """
     error_msg = "Failed to properly execute the API function"
 
 
 class APIForbidden(APIError):
-    """ An exception in an API-related function that was unable to properly interact with the Hiven servers """
+    """
+    An exception in an API-related function that was unable to properly
+    interact with the Hiven servers
+    """
     error_msg = "You do not have the permission to perform this action"
 
 
@@ -261,7 +278,8 @@ class InvalidPassedDataError(InitializationError):
         if args:
             arg = "".join([str(arg) for arg in args])
         else:
-            arg = "The initializer failed to validate and utilise the data likely due to wrong data passed!"
+            arg = "The initializer failed to validate and utilise the data " \
+                  "likely due to wrong data passed!"
 
         if data:
             arg += f"\n Data: {data}"
@@ -272,8 +290,11 @@ class InvalidPassedDataError(InitializationError):
 
 
 class ExecutionLoopError(HivenError):
-    """ An exception occurred in the execution loop running parallel to the core """
-    error_msg = "An exception occurred in the execution loop running parallel to the core"
+    """
+    An exception occurred in the execution loop running parallel to the core
+    """
+    error_msg = "An exception occurred in the execution loop running parallel " \
+                "to the core"
 
 
 class ExecutionLoopStartError(HivenError):

--- a/openhivenpy/gateway/__init__.py
+++ b/openhivenpy/gateway/__init__.py
@@ -300,7 +300,9 @@ class Connection(HivenObject):
                or not self.socket_closed):
             await asyncio.sleep(.05)
 
-    async def close(self, force: bool = False) -> None:
+    async def close(
+            self, force: bool = False, remove_listeners: bool = True
+    ) -> None:
         """
         Closes the Connection to Hiven and stops the running WebSocket and the
         Event Processing Loop
@@ -313,6 +315,9 @@ class Connection(HivenObject):
          forced closed, which may lead to running code of event-listeners being
          stopped while performing actions. If False the stopping will wait for
          all running event_listeners to finish
+        :param remove_listeners: If sett to True, it will remove all listeners
+         including the ones created using @client.event(), add_multi_listener()
+         and add_single_listener()
         """
         try:
             self._connection_status = "CLOSING"
@@ -340,4 +345,5 @@ class Connection(HivenObject):
                 "Failed to stop client due to an exception occurring"
             ) from e
         finally:
-            self.client.cleanup_listeners()
+            if remove_listeners:
+                self.client.cleanup_listeners()

--- a/openhivenpy/gateway/__init__.py
+++ b/openhivenpy/gateway/__init__.py
@@ -165,17 +165,25 @@ class Connection(HivenObject):
     async def connect(self, restart: bool) -> None:
         """
         Establishes a connection to Hiven and runs the background processes.
-        Only closes if forced to using close() or an exception is raised and restart is False
+        Only closes if forced to using close() or an exception is raised and
+        restart is False
         """
         try:
             self._connection_status = "OPENING"
-            self.http = HTTP(self.client, host=self.host, api_version=self.api_version)
+            self.http = HTTP(
+                self.client,
+                host=self.host,
+                api_version=self.api_version
+            )
             await self.http.connect()
 
             while self.connection_status == "OPENING":
                 try:
                     coro = HivenWebSocket.create_from_client(
-                        self.client, endpoint=self.endpoint, close_timeout=self.close_timeout, heartbeat=self.heartbeat,
+                        self.client,
+                        endpoint=self.endpoint,
+                        close_timeout=self.close_timeout,
+                        heartbeat=self.heartbeat,
                         loop=self.loop
                     )
                     self._ws = await asyncio.wait_for(coro, 30)
@@ -241,7 +249,9 @@ class Connection(HivenObject):
                 brief=f"Failed to keep alive current connection to Hiven:",
                 exc_info=sys.exc_info()
             )
-            raise SessionCreateError(f"Failed to establish HivenClient session") from e
+            raise SessionCreateError(
+                f"Failed to establish HivenClient session"
+            ) from e
         finally:
             self._closing = True
             self._reset_status("CLOSING")

--- a/openhivenpy/gateway/__init__.py
+++ b/openhivenpy/gateway/__init__.py
@@ -329,3 +329,5 @@ class Connection(HivenObject):
             raise RuntimeError(
                 "Failed to stop client due to an exception occurring"
             ) from e
+        finally:
+            self.client.cleanup_listeners()

--- a/openhivenpy/gateway/messagebroker.py
+++ b/openhivenpy/gateway/messagebroker.py
@@ -167,14 +167,21 @@ class MessageBroker(HivenObject):
         self._cleanup_buffers()
 
     async def run(self) -> None:
-        """ Runs the event_consumer instance which stores the workers for all event_listeners """
-        self.worker_loop = asyncio.create_task(self.event_consumer.run_all_workers())
+        """
+        Runs the event_consumer instance which stores the workers for all
+        event_listeners
+        """
+        self.worker_loop = asyncio.create_task(
+            self.event_consumer.run_all_workers()
+        )
         try:
             await self.worker_loop
         except asyncio.CancelledError:
             logger.debug("Event Consumer stopped! All workers are cancelled!")
         except Exception as e:
-            raise EventConsumerLoopError("The event_consumer process loop failed to be kept alive") from e
+            raise EventConsumerLoopError(
+                "The event_consumer process loop failed to be kept alive"
+            ) from e
 
 
 class Worker(HivenObject):
@@ -194,7 +201,7 @@ class Worker(HivenObject):
     def __repr__(self):
         info = [
             ('event', self.assigned_event),
-            ('done', self.done)
+            ('done', self.done())
         ]
         return '<{} {}>'.format(
             self.__class__.__name__, ' '.join('%s=%s' % t for t in info)
@@ -222,11 +229,11 @@ class Worker(HivenObject):
     def done(self) -> bool:
         """
         Returns whether the process is finished and all tasks finished
-        correctly
+        correctly. If it hasn't started yet it will also return False
         """
         return all([
             self._tasks_done,
-            self._sequence_loop.done(),
+            self._sequence_loop.done() if self._sequence_loop else False,
             self._cancel_called
         ])
 

--- a/openhivenpy/types/usertyping.py
+++ b/openhivenpy/types/usertyping.py
@@ -34,7 +34,9 @@ class UserTyping(DataClassObject):
             self._timestamp = data.get('timestamp')
 
         except Exception as e:
-            raise InitializationError(f"Failed to initialise {self.__class__.__name__}") from e
+            raise InitializationError(
+                f"Failed to initialise {self.__class__.__name__}"
+            ) from e
         else:
             self._client = client
 

--- a/openhivenpy/utils.py
+++ b/openhivenpy/utils.py
@@ -222,17 +222,19 @@ def safe_convert(
         dtype: Any, value: Any, default: Optional[Any] = MISSING
 ) -> Union[Any, None]:
     """
-    Converts the passed value if it is not None, if it is it will just return
-    None to not cause an exception.
-
-    Returns the passed default if the conversion failed.
-    If the default is missing it will raise the conversion exception.
+    Converts the passed value. If the conversion fails or the value is None
+    it will simply return the default if it not (the default) MISSING. If
+    that's the case:
+    - if it failed due to conversion error it will reraise the Exception.
+    - else if the value was None it will return None as well.
 
     :param dtype: The datatype the value should be returned
     :param value: The value that should be converted
     :param default: The default value that should be returned if the conversion
      failed
     :return: The converted value or the default passed value
+    :raises Exception: If default is MISSING and the conversion raised an
+     exception.
     """
     try:
         if value is None:
@@ -279,8 +281,10 @@ def update_and_return(dictionary: dict, **kwargs) -> dict:
     return dictionary
 
 
-def wrap_with_logging(func: Union[Callable, Awaitable] = None,
-                      return_exception: bool = False) -> Union[Callable, Awaitable]:
+def wrap_with_logging(
+        func: Union[Callable, Awaitable] = None,
+        return_exception: bool = False
+) -> Union[Callable, Awaitable]:
     """
     Wraps a function and adds traceback logging
 
@@ -296,11 +300,14 @@ def wrap_with_logging(func: Union[Callable, Awaitable] = None,
                     return await func(*args, **kwargs)
                 except Exception as e:
                     log_traceback(
-                        brief=f"{'' if return_exception else 'Ignoring'} Exception in coroutine {func.__name__}:",
+                        brief=f"{'' if return_exception else 'Ignoring'} "
+                              f"Exception in coroutine {func.__name__}:",
                         exc_info=sys.exc_info()
                     )
                     if return_exception:
-                        raise RuntimeError(f"Failed to execute coroutine {func.__name__}") from e
+                        raise RuntimeError(
+                            f"Failed to execute coroutine {func.__name__}"
+                        ) from e
         else:
             @wraps(func)
             def wrapper(*args, **kwargs) -> Union[Any, NoReturn]:
@@ -308,11 +315,14 @@ def wrap_with_logging(func: Union[Callable, Awaitable] = None,
                     return func(*args, **kwargs)
                 except Exception as e:
                     log_traceback(
-                        brief=f"{'' if return_exception else 'Ignoring'} Exception in function {func.__name__}:",
+                        brief=f"{'' if return_exception else 'Ignoring'} "
+                              f"Exception in function {func.__name__}:",
                         exc_info=sys.exc_info()
                     )
                     if return_exception:
-                        raise RuntimeError(f"Failed to execute function {func.__name__}") from e
+                        raise RuntimeError(
+                            f"Failed to execute function {func.__name__}"
+                        ) from e
 
         return wrapper  # func can still be used normally
 

--- a/pytest/test_client/test_hivenclient.py
+++ b/pytest/test_client/test_hivenclient.py
@@ -53,7 +53,7 @@ class TestHivenClient:
         @client.event()
         async def on_ready():
             print("\non_ready was called!")
-            await client.close()
+            await client.close(remove_listeners=False)
 
         client.run(self.token)
         client.run(self.token)

--- a/pytest/test_client/test_load_env_vars.py
+++ b/pytest/test_client/test_load_env_vars.py
@@ -22,15 +22,16 @@ class TestENV:
         assert '128' == openhivenpy.env.env_vars['BOT_TOKEN_LEN']
 
     def test_load_false(self):
-        openhivenpy.env.load_env(path=self.FALSE_PATH, search_other=True)  # <== correct.env
-        assert '128' == openhivenpy.env.env_vars['BOT_TOKEN_LEN']
+        _ = openhivenpy.env.load_env(path=self.FALSE_PATH, search_other=True)
+        assert '132' == openhivenpy.env.env_vars['BOT_TOKEN_LEN']
 
-        openhivenpy.env.load_env(path=self.FALSE_PATH, search_other=False)  # <== openhivenpy.env
+        openhivenpy.env.load_env(path=self.FALSE_PATH,
+                                 search_other=False)  # <== openhivenpy.env
         assert default_env_vars == openhivenpy.env.env_vars
         assert '132' == openhivenpy.env.env_vars['BOT_TOKEN_LEN']
 
         openhivenpy.env.unload_env()
-        assert False is openhivenpy.env.load_env_file(path=self.FALSE_PATH)[1]
+        assert openhivenpy.env.load_env_file(path=self.FALSE_PATH)[1] is True
 
     def test_load_correct(self):
         assert openhivenpy.env.load_env_file(path=self.CORRECT_PATH)[1]  # <== correct.env

--- a/pytest/test_client/test_load_env_vars.py
+++ b/pytest/test_client/test_load_env_vars.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from pathlib import Path
 
 import openhivenpy
 
@@ -10,8 +11,8 @@ default_env_vars = openhivenpy.env.env_vars  # <== openhivenpy.env
 
 
 class TestENV:
-    CORRECT_PATH = f'{os.path.dirname(__file__)}\\correct.env'
-    FALSE_PATH = f'{os.path.dirname(__file__)}\\false.env'
+    CORRECT_PATH = str(Path(f'{os.path.dirname(__file__)}') / f'correct.env')
+    FALSE_PATH = str(Path(f'{os.path.dirname(__file__)}') / 'false.env')
 
     def test_load(self):
         openhivenpy.env.load_env(search_other=False)  # <== openhivenpy.env

--- a/pytest/test_core/test_events.py
+++ b/pytest/test_core/test_events.py
@@ -195,7 +195,8 @@ class TestHivenEventHandler:
             await client.call_listeners('ready', (), {})
 
         async def run():
-            assert not client.active_listeners
+            assert (not client.active_listeners or
+                    len(client.active_listeners['ready']) == 0)
 
             client.add_single_listener(event_name='ready', awaitable=on_ready)
             # Checking if the listener was added correctly

--- a/pytest/test_core/test_events.py
+++ b/pytest/test_core/test_events.py
@@ -195,7 +195,7 @@ class TestHivenEventHandler:
             await client.call_listeners('ready', (), {})
 
         async def run():
-            assert len(client.active_listeners['ready']) == 0
+            assert not client.active_listeners
 
             client.add_single_listener(event_name='ready', awaitable=on_ready)
             # Checking if the listener was added correctly

--- a/pytest/test_core/test_message_broker.py
+++ b/pytest/test_core/test_message_broker.py
@@ -79,8 +79,10 @@ class TestWorker:
         assert worker.assigned_event == "ready"
         assert worker.message_broker == message_broker
         assert worker.client == message_broker.client
-        assert worker.assigned_event_buffer == message_broker.event_buffers['ready']
-        assert repr(worker) == f'<Worker event={worker.assigned_event}>'
+        assert worker.assigned_event_buffer == message_broker.event_buffers[
+            'ready']
+        assert repr(worker) == \
+               f'<Worker event={worker.assigned_event} done=False>'
 
     def test_run_one_sequence(self):
         client = openhivenpy.UserClient()

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("requirements.txt") as file:
 
 setuptools.setup(
     name="openhivenpy",
-    version="0.1.4",
+    version="0.2.dev1",
     author="Luna Klatzer",
     author_email="luna.klatzer@gmail.com",
     description="The OpenSource Python API Wrapper and Bot-Framework for Hiven",

--- a/setup.py
+++ b/setup.py
@@ -17,10 +17,10 @@ setuptools.setup(
     license="MIT",
     url="https://github.com/Luna-Klatzer/openhiven.py",
     project_urls={
-        "Docs": "https://Luna-Klatzer.github.io/docs_openhiven.py",
-        "Hiven API Docs": "https://openhivenpy.readthedocs.io/en/latest/api_reference/",
+        "Docs": "https://luna-klatzer.github.io/docs_openhiven.py/latest/",
+        "Hiven API Docs": "https://luna-klatzer.github.io/docs_openhiven.py/latest/api_reference/",
         "Issue-Page": "https://github.com/Luna-Klatzer/openhiven.py/issues/",
-        "Changelog": "https://openhivenpy.readthedocs.io/en/mkdocs-material-rewrite/changelog.html"
+        "Changelog": "https://luna-klatzer.github.io/docs_openhiven.py/latest/changelog.html"
     },
     packages=setuptools.find_packages(),
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("requirements.txt") as file:
 
 setuptools.setup(
     name="openhivenpy",
-    version="0.2.alpha1",
+    version="0.1.4",
     author="Luna Klatzer",
     author_email="luna.klatzer@gmail.com",
     description="The OpenSource Python API Wrapper and Bot-Framework for Hiven",


### PR DESCRIPTION
## Summary

Merging changes made in main into v0.2.dev to continue development

## Introduced Changes
- Added HTTP exception `HTTPRateLimitError` and rate-limit handling 
- Added remove_listeners to HivenClient.close() to cleanup listeners
- Fixed recursion error in `Worker.__repr__`
- Fixed syntax issue in workflows
- Dot-Env handling to fix bugs when loading them. The default file will always be loaded and any other file will be loaded on top of it.
 
## Is this PR related to an issue or problem
No.

## Does your new code introduce new warnings or errors? (At current state)

No, but fixes previous errors

## Changelog

### Added
- `HTTPRateLimitError` for receiving http rate-limits (429) and parameter
  retry_on_rate_limit to raw_request()
- Parameter `remove_listeners` to `HivenClient.close()`, which will, if set to
  True, remove all listeners created using @client.event(),
  add_multi_listener() and add_single_listener()

### Changed
- Dot-Env Handling, which will now load the openhivenpy.env file on default and
  update all variables based on the given input. This will avoid None values
  when an .env file only updates a few values

